### PR TITLE
ci: use GitHub pages live demo

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,28 @@
+name: website
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install package dependencies
+        run: yarn install
+      - run: yarn test:ci
+      - name: Build Gatsby site
+        run: yarn build
+      - name: Deploy to GitHub Pages
+        if: success()
+        uses: crazy-max/ghaction-github-pages@v2
+        with:
+          target_branch: gh-pages
+          build_dir: packages/example/public
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   Gatsby Theme ADR
 </h1>
 
-Visit [live demo](https://main-6tkhgrnroe6hhbnhw96k7zaeo8qu1pem.tugboat.qa/). <small>Live demo via <a href="https://main-6tkhgrnroe6hhbnhw96k7zaeo8qu1pem.tugboat.qa/">Tugboat</a></small>.
+Visit [live demo](https://lullabot.github.io/gatsby-theme-adr).
 
 ## 🚀 Add an ADR website to your software project
 


### PR DESCRIPTION
For the live demo on the `main` branch.