### PR TITLE
fix: Support the trailingSlash option

### DIFF
--- a/packages/example/gatsby-config.js
+++ b/packages/example/gatsby-config.js
@@ -4,6 +4,7 @@ module.exports = {
       resolve: '@lullabot/gatsby-theme-adr',
       options: {
         contentPath: 'adrs',
+        trailingSlash: 'always',
         siteMetadata: {
           siteUrl: 'https://architecture.my-company.com',
           title: "My Company's Architecture Decision Records",

--- a/packages/gatsby-theme-adr/gatsby-config.js
+++ b/packages/gatsby-theme-adr/gatsby-config.js
@@ -12,6 +12,7 @@ module.exports = ({
 }) => ({
   jsxRuntime: 'automatic',
   siteMetadata,
+  trailingSlash: 'always',
   plugins: [
     'gatsby-plugin-image',
     'gatsby-plugin-react-helmet',

--- a/packages/gatsby-theme-adr/src/components/AdrToc.tsx
+++ b/packages/gatsby-theme-adr/src/components/AdrToc.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { graphql, useStaticQuery } from 'gatsby';
+import { Link, graphql, useStaticQuery } from 'gatsby';
 
 type AdrToc = {
   id: string;
@@ -13,12 +13,12 @@ function TocLink({
 }: LinkParts & { depth: number }) {
   return (
     <li>
-      <a
-        href={url}
+      <Link
+        to={url}
         className="text-blue-500 flex items-center ml-2 mt-1 px-2 py-1 text-sm font-medium hover:text-blue-800 hover:underline"
       >
         <span className="truncate">{title}</span>
-      </a>
+      </Link>
       {items && items.length ? (
         <ul className={`ml-${depth * 2} mt-0.5`}>
           {items.map((item, index) => (

--- a/packages/gatsby-theme-adr/src/components/PageBreadcrumbs.tsx
+++ b/packages/gatsby-theme-adr/src/components/PageBreadcrumbs.tsx
@@ -1,5 +1,6 @@
 import React, { ReactElement } from 'react';
 import { ChevronRightIcon, HomeIcon } from '@heroicons/react/outline';
+import { Link } from 'gatsby';
 
 type PageBreadcrumbsProps = { uri: string; title: string };
 const PageBreadcrumbs = ({
@@ -28,13 +29,13 @@ const PageBreadcrumbs = ({
                 className="flex-shrink-0 h-5 w-5 text-charcoal-700"
                 aria-hidden="true"
               />
-              <a
-                href={page.href}
+              <Link
+                to={page.href}
                 className="ml-4 text-sm font-medium text-charcoal-700 hover:text-charcoal-800"
                 aria-current={page.current ? 'page' : undefined}
               >
                 {page.name}
-              </a>
+              </Link>
             </div>
           </li>
         ))}


### PR DESCRIPTION
Gatsby now supports a trailingSlash option which notably is required for GitHub pages. Otherwise, a redirect will be issued to add the slash and Google won't index the resulting page.

https://www.gatsbyjs.com/docs/reference/config-files/gatsby-config/#trailingslash

I had trouble testing this as I had to remove the `.cache` and possibly the `packages/example/public/` directory too for the new options to be picked up.

Gatsby will be defaulting to `always` in gatsby 5, so I've added the option set to that for new sites.

<img width="772" alt="image" src="https://user-images.githubusercontent.com/255023/190922228-38519b79-a7cf-492f-9cbc-8f1c3365678f.png">

<img width="2039" alt="image" src="https://user-images.githubusercontent.com/255023/190922238-940dadeb-080c-49a3-802a-58baed18b28a.png">
