### PR TITLE
feat: make social links configuration optional

### DIFF
--- a/packages/gatsby-theme-adr/gatsby-node.js
+++ b/packages/gatsby-theme-adr/gatsby-node.js
@@ -145,3 +145,27 @@ exports.createPages = async ({ graphql, actions, reporter }) => {
     createAdrDetail(createPage, graphql, reporter),
   ]);
 };
+
+// Define SiteMetadata type schema to allow for optional socialLinks.
+exports.createSchemaCustomization = ({ actions }) => {
+  actions.createTypes(`
+    type Site {
+      siteMetadata: SiteMetadata!
+    }
+
+    type SiteMetadata {
+      siteUrl: String!
+      title: String!
+      description: String!
+      image: String!
+      menuLinks: [IconLink!]!
+      socialLinks: [IconLink!]
+    }
+
+    type IconLink {
+      name: String!
+      uri: String!
+      iconName: String
+    }
+  `);
+};

--- a/packages/gatsby-theme-adr/src/components/layout/Footer.tsx
+++ b/packages/gatsby-theme-adr/src/components/layout/Footer.tsx
@@ -26,7 +26,7 @@ const Footer = ({ links, socialLinks }: FooterProps): ReactElement => {
           ))}
         </nav>
         <div className="xl:ml-6 ml-3 hidden sm:flex justify-center space-x-6">
-          {socialLinks.map(({ name, uri, iconName }) => {
+          {socialLinks?.map(({ name, uri, iconName }) => {
             return (
               <span key={name} className="text-gray-400 hover:text-gray-500">
                 <span className="sr-only">{name}</span>


### PR DESCRIPTION
Resolves https://github.com/Lullabot/gatsby-theme-adr/issues/59.
Allows providing empty value for `socialLinks` configuration option or to skip it entirely.